### PR TITLE
Fix minors

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -46,4 +46,4 @@
   - [Versioning](/dto.md?id=versioning)
   - [DTO extensions](/dto.md?id=dto-extensions)
 
-- [Alternatives (why not to use XYZ?)](/alternatives.md)
+- [FAQ](/faq.md)

--- a/alternatives.md
+++ b/alternatives.md
@@ -3,29 +3,34 @@
 ## FOSRestBundle
 
 It is the first trial to standardize the way to write REST APIs routes and controllers in Symfony.  
-It is limited in its features as do not offer filtering or pagination utilities, is controller-based 
-(and not resource-based) and contains too much magic in routes registration, but has decoupled
-view handling and serialization which inspired some concepts of Solido.
+
+It is _controller-based_ (instead of _resource-based_), does not offer _filtering_ or _pagination_ utilities, and contains _too much magic_ in routes registration. 
+
+Otherwise has _decoupled view handling_ and _serialization_ which inspired some of the Solido core concepts.
 
 ## API Platform
 
-It is a more complete solution to build a REST API in Symfony. It is resource-centric but has
-no versioning support at all, limited list filtering, non-RESTful pagination support, non-coherent request
-error handling, limited resource PATCH support and an overall orientation to CRUD and RAD which makes very
-difficult to customize its behaviors.  
-Additionally it is tightly coupled to Symfony Serializer component which has limited functionalities and
-very hard to extend thanks to its final classes paired with very long private methods.
+It is a more complete solution to build a REST API in Symfony. 
 
-All its components are packaged in one single library and it is nearly impossible to install only the used components.
+It is _resource-centric_ and is great for prototyping and rapid develop (**RAD**) a **CRUD** 
+service but it's a bit rigid and is pretty difficult to customize its default behaviors.
 
-It has some good features such as jsonld support and graphql, but they are major drawbacks when working
+It lacks _versioning_ support, limited _list filtering_, _non-RESTful pagination_ support, _not-coherent request
+error handling_ and a _limited resource PATCH_ support.  
+
+Additionally it is tightly coupled to [Symfony Serializer](https://symfony.com/doc/current/components/serializer.html) component which has limited functionalities and
+is very hard to extend thanks to its _final classes_ paired with very long private methods.
+
+API Platform is _not that modular_: all its components are packaged in one single library and it is nearly impossible to install only the used components.
+
+It also has some good features such as **jsonld** support and **graphql**, but they are major drawbacks when working
 with multiple applications or microservices as the application do not know anything about the other services’ resources.
-
-However it is great for prototyping and rapid development, but cannot be really used for a serious
-project with external integration.
 
 ## Laminas API Tools
 
-Probably the easiest way to create an API project in PHP, it is obviously coupled to the Laminas project
-(formerly Zend Framework). It is feature complete, but the project went probably out of scope handling 
+Probably the easiest way to create an API project in PHP.
+
+It is obviously _coupled to the Laminas project_ (formerly **Zend Framework**). 
+
+It is _feature complete_, but the project went probably _out of scope_ handling 
 non-API related things like authentication via OAuth or social log in.

--- a/alternatives.md
+++ b/alternatives.md
@@ -23,8 +23,9 @@ is very hard to extend thanks to its _final classes_ paired with very long priva
 
 API Platform is _not that modular_: all its components are packaged in one single library and it is nearly impossible to install only the used components.
 
-It also has some good features such as **jsonld** support and **graphql**, but they are major drawbacks when working
-with multiple applications or microservices as the application do not know anything about the other services’ resources.
+It also has some good features such as **jsonld** support and **graphql**, but in its implementation there are some major drawbacks working in a domain 
+with multiple services, for example referencing their identifiers but not being able to expose their schemas natively. 
+There are multiple solutions to workaround this but it's quite a bit of additional effort at the moment of writing.
 
 ## Laminas API Tools
 

--- a/dto-management.md
+++ b/dto-management.md
@@ -53,7 +53,7 @@ src              (App\)
 You can then create a dto registry and an associated resolver with:
 
 ```php
-$serviceLocatoryRegistry = \Solido\DtoManagement\Finder\ServiceLocatorRegistry::createFromNamespace('App\DTO');
+$serviceLocatorRegistry = \Solido\DtoManagement\Finder\ServiceLocatorRegistry::createFromNamespace('App\DTO');
 $resolver = new \Solido\DtoManagement\InterfaceResolver\Resolver($serviceLocatorRegistry);
 ```
 
@@ -90,7 +90,7 @@ $configuration = new \Solido\DtoManagement\Proxy\Factory\Configuration();
 $configuration->addExtension(new \Solido\DataTransformers\TransformerExtension());
 
 $proxyFactory = new \Solido\DtoManagement\Proxy\Factory\AccessInterceptorFactory($configuration);
-$serviceLocatoryRegistry = \Solido\DtoManagement\Finder\ServiceLocatorRegistry::createFromNamespace('App\DTO', proxyFactory: $proxyFactory);
+$serviceLocatorRegistry = \Solido\DtoManagement\Finder\ServiceLocatorRegistry::createFromNamespace('App\DTO', proxyFactory: $proxyFactory);
 ```
 
 ## Proxy factory configuration

--- a/dto.md
+++ b/dto.md
@@ -81,7 +81,7 @@ class User implements UserInterface
     public $name;
     public $email;
 
-    public funcion get(Entity\User $user): self
+    public function get(Entity\User $user): self
     {
         $this->name = $user->getName();
         $this->email = $user->getEmail();
@@ -102,7 +102,7 @@ class User implements UserInterface
     public $email;
     public $phone;      // New field
 
-    public funcion get(Entity\User $user): self
+    public function get(Entity\User $user): self
     {
         $this->name = $user->getName();
         $this->email = $user->getEmail();
@@ -117,7 +117,7 @@ Now, with the `ServiceLocatorRegistry` and `Resolver` utilities from dto-managem
 a new instance of the `UserInterface` DTO just passing the version you want to retrieve to the resolver
 
 ```php
-$serviceLocatoryRegistry = \Solido\DtoManagement\Finder\ServiceLocatorRegistry::createFromNamespace('App\DTO');
+$serviceLocatorRegistry = \Solido\DtoManagement\Finder\ServiceLocatorRegistry::createFromNamespace('App\DTO');
 $resolver = new \Solido\DtoManagement\InterfaceResolver\Resolver($serviceLocatorRegistry);
 
 $resolver->resolve(UserInterface::class, '1.0');

--- a/dto.md
+++ b/dto.md
@@ -143,8 +143,8 @@ A DTO extension could add methods and properties or generate interceptors for ex
 [Data transformer component](./data-transformers.md) has one of these extensions which analyzes the DTO classes
 via reflection and generates interceptors for transforming input data on property set or method call.
 
-!> Generated code is only available while retrieving DTOs from a resolver. If you create a DTO instance with the `new`
-keyword, the generated code will not be available as it is only present in the generated proxies.
+!> Generated code is only available while retrieving DTOs from a resolver. That's why if you instantiate a DTO object with the `new`
+construct keyword, the generated code will not be available.
 
 ### Writing a custom extension
 
@@ -152,15 +152,15 @@ DTO extensions must implement the `Solido\DtoManagement\Proxy\Extension\Extensio
 on `AccessInterceptorFactory` configuration ([check the documentation on how to register an extension](./dto-management.md?id=how-to-use-dto-extensions)).
 
 The `ExtensionInterface` exposes only one method (`extend`) which accepts a `ProxyBuilder` object.  
-The `ProxyBuilder` object is all what you need to add interfaces, traits, methods and properties to the generated proxy,
+The `ProxyBuilder` object is what you need to add interfaces, traits, methods and properties to the generated proxy,
 as well as add interceptors for methods and properties. Its `class` property gives you access to the `ReflectionClass`
 object of the versioned DTO being extended and the `properties` attribute should help you to filter and iterate through
 the DTO public and protected properties.
 
 !> NOTE: Interceptors for private properties and methods cannot be created.
 
-`ProxyBuilder` methods should be self-explanatory, but feel free to ask questions opening an issue on
-dto-management repository. The responses will be included in this documentation to be helpful to other developers.
+`ProxyBuilder` methods should be self-explanatory, but feel free to ask questions [opening an issue on dto-management repository](https://github.com/solid-o/dto-management/issues). 
+The responses will be included in this documentation to be helpful to other developers.
 
 Through `ProxyBuilder` you can statically analyze the DTO class, search for attributes/annotations, load metadata
 and generate public or protected methods, properties or interceptors for public and protected properties or methods.

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,8 @@
-# Alternatives - why not to use ... ?
+# FAQ
 
-## FOSRestBundle
+## 1) Why not to use ... ?
+
+### FOSRestBundle
 
 It is the first trial to standardize the way to write REST APIs routes and controllers in Symfony.  
 
@@ -8,7 +10,7 @@ It is _controller-based_ (instead of _resource-based_), does not offer _filterin
 
 Otherwise has _decoupled view handling_ and _serialization_ which inspired some of the Solido core concepts.
 
-## API Platform
+### API Platform
 
 It is a more complete solution to build a REST API in Symfony. 
 
@@ -27,7 +29,7 @@ It also has some good features such as **jsonld** support and **graphql**, but i
 with multiple services, for example referencing their identifiers but not being able to expose their schemas natively. 
 There are multiple solutions to workaround this but it's quite a bit of additional effort at the moment of writing.
 
-## Laminas API Tools
+### Laminas API Tools
 
 Probably the easiest way to create an API project in PHP.
 

--- a/index.md
+++ b/index.md
@@ -14,6 +14,8 @@ It also provides integration with the popular PHP framework Symfony (integration
 Solido is built as a set of libraries and tools that eases the development of a REST API in a framework agnostic way.  
 Framework integrations are welcome (at the moment only the Symfony one is present) but are not needed to run the standalone components.
 
+If you are interested why we decided not to use other php alternative libraries take a look to our [FAQ](./faq.md) section.
+
 ## Components
 
 - [body-converter](./body-converter.md): normalize body into a request object to be handled without special Content-Type checks

--- a/query-language.md
+++ b/query-language.md
@@ -40,8 +40,8 @@ All the operators starts with a dollar sign ($) and the argument(s) are enclosed
 - `$eq(value)`: equals, field must be exactly equal to `value`. This operator is implicitly applied when passing a string to a filter
 - `$neq(value)`: not equals, shortcut for `$not($eq(value))`
 - `$like(value)`: matches when `value` is contained case-insensitively into the specified field
-- `$gt(value)` and `$gte(value)`: greater than and greater than or equal, used to compare numeric or date values
-- `$lt(value)` and `$lte(value)`: less than and less than or equal, same as above
+- `$gt(value)` and `$gte(value)`: _greater than_ and _greater than or equal_, used to compare numeric or date values
+- `$lt(value)` and `$lte(value)`: _less than_ and _less than or equal_, same as above
 - `$range(lower, upper)`: matches when the value is contained in the *inclusive* range `[lower, upper]`
 - `$and(...)`: matches when all the expressions contained match
 - `$or(...)`: matches when one of the expressions contained match


### PR DESCRIPTION
This PR fix a couple of typos here and there and tries to reword some paragraphs on the `alternatives.md` section focusing more on their features instead of lacks.
I was thinking about a feature comparative table between these alternatives but imho it's a bit too difficult to clarify backdrops for example for `Laminas API Tools` since the main issue is to being highly coupled with its framework.

Also why not to add a `FAQ` section (or rename it to) to collect this kind of answers (_Alternatives_) and maybe link it as soon as possible in other sections (eg: index.md >> Philosophy) to help new comers?